### PR TITLE
fixed stick parity typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 * Added conversions between `DataBits`, `StopBits` types and their numeric representations
 * Added `FromStr` implementation for `FlowControl`
+* Added `Mark` and `Space` variants to `Parity` enum
 ### Changed
 ### Fixed
 * Fixes a bug where `available_ports()` returned disabled devices on Windows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,13 +208,11 @@ pub enum Parity {
     /// Parity bit is set to 1.
     ///
     /// Only supported on Windows and Linux.
-    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
     Mark,
 
     /// Parity bit is set to 0.
     ///
     /// Only supported on Windows and Linux.
-    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
     Space,
 }
 
@@ -224,9 +222,7 @@ impl fmt::Display for Parity {
             Parity::None => write!(f, "None"),
             Parity::Odd => write!(f, "Odd"),
             Parity::Even => write!(f, "Even"),
-            #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
             Parity::Mark => write!(f, "Mark"),
-            #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
             Parity::Space => write!(f, "Space"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,16 @@ pub enum Parity {
 
     /// Parity bit sets even number of 1 bits.
     Even,
+
+    /// Parity bit is set to 1.
+    ///
+    /// Only supported on Windows and Linux.
+    Mark,
+
+    /// Parity bit is set to 0.
+    ///
+    /// Only supported on Windows and Linux.
+    Space,
 }
 
 impl fmt::Display for Parity {
@@ -212,6 +222,8 @@ impl fmt::Display for Parity {
             Parity::None => write!(f, "None"),
             Parity::Odd => write!(f, "Odd"),
             Parity::Even => write!(f, "Even"),
+            Parity::Mark => write!(f, "Mark"),
+            Parity::Space => write!(f, "Space"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,11 +208,13 @@ pub enum Parity {
     /// Parity bit is set to 1.
     ///
     /// Only supported on Windows and Linux.
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
     Mark,
 
     /// Parity bit is set to 0.
     ///
     /// Only supported on Windows and Linux.
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
     Space,
 }
 
@@ -222,7 +224,9 @@ impl fmt::Display for Parity {
             Parity::None => write!(f, "None"),
             Parity::Odd => write!(f, "Odd"),
             Parity::Even => write!(f, "Even"),
+            #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
             Parity::Mark => write!(f, "Mark"),
+            #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
             Parity::Space => write!(f, "Space"),
         }
     }

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -163,6 +163,26 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) {
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
         }
+        Parity::Mark => {
+            termios.c_cflag |= libc::PARODD;
+            termios.c_cflag |= libc::PARENB;
+            termios.c_iflag |= libc::INPCK;
+            termios.c_iflag &= !libc::IGNPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag |= libc::CMSPAR;
+            }
+        }
+        Parity::Space => {
+            termios.c_cflag &= !libc::PARODD;
+            termios.c_cflag |= libc::PARENB;
+            termios.c_iflag |= libc::INPCK;
+            termios.c_iflag &= !libc::IGNPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag |= libc::CMSPAR;
+            }
+        }
     };
 }
 

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -154,17 +154,29 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
             termios.c_cflag &= !(libc::PARENB | libc::PARODD);
             termios.c_iflag &= !libc::INPCK;
             termios.c_iflag |= libc::IGNPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag &= !libc::CMSPAR;
+            }
         }
         Parity::Odd => {
             termios.c_cflag |= libc::PARENB | libc::PARODD;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag &= !libc::CMSPAR;
+            }
         }
         Parity::Even => {
             termios.c_cflag &= !libc::PARODD;
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag &= !libc::CMSPAR;
+            }
         }
         #[cfg(any(target_os = "linux", target_os = "android"))]
         Parity::Mark => {

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -163,21 +163,25 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) {
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
         }
-        #[cfg(any(target_os = "linux", target_os = "android"))]
         Parity::Mark => {
             termios.c_cflag |= libc::PARODD;
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
-            termios.c_iflag |= libc::CMSPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag |= libc::CMSPAR;
+            }
         }
-        #[cfg(any(target_os = "linux", target_os = "android"))]
         Parity::Space => {
             termios.c_cflag &= !libc::PARODD;
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
-            termios.c_iflag |= libc::CMSPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag |= libc::CMSPAR;
+            }
         }
     };
 }

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -145,7 +145,10 @@ pub(crate) fn set_termios(fd: RawFd, termios: &Termios) -> Result<()> {
     crate::posix::ioctl::tcsets2(fd, termios)
 }
 
-pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) {
+// The Result return will seem pointless on platforms that support all parity variants, but we need
+// it for the others.
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
     match parity {
         Parity::None => {
             termios.c_cflag &= !(libc::PARENB | libc::PARODD);
@@ -163,27 +166,38 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) {
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
         }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         Parity::Mark => {
             termios.c_cflag |= libc::PARODD;
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            {
-                termios.c_iflag |= libc::CMSPAR;
-            }
+            termios.c_iflag |= libc::CMSPAR;
         }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         Parity::Space => {
             termios.c_cflag &= !libc::PARODD;
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            {
-                termios.c_iflag |= libc::CMSPAR;
-            }
+            termios.c_iflag |= libc::CMSPAR;
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        Parity::Mark => {
+            return Err(crate::Error::new(
+                crate::ErrorKind::InvalidInput,
+                "Mark parity not supported on this platform",
+            ));
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        Parity::Space => {
+            return Err(crate::Error::new(
+                crate::ErrorKind::InvalidInput,
+                "Space parity not supported on this platform",
+            ));
         }
     };
+    Ok(())
 }
 
 pub(crate) fn set_flow_control(termios: &mut Termios, flow_control: FlowControl) {

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -163,25 +163,21 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) {
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
         }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         Parity::Mark => {
             termios.c_cflag |= libc::PARODD;
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            {
-                termios.c_iflag |= libc::CMSPAR;
-            }
+            termios.c_iflag |= libc::CMSPAR;
         }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         Parity::Space => {
             termios.c_cflag &= !libc::PARODD;
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            {
-                termios.c_iflag |= libc::CMSPAR;
-            }
+            termios.c_iflag |= libc::CMSPAR;
         }
     };
 }

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -156,7 +156,7 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
             termios.c_iflag |= libc::IGNPAR;
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
-                termios.c_iflag &= !libc::CMSPAR;
+                termios.c_cflag &= !libc::CMSPAR;
             }
         }
         Parity::Odd => {
@@ -165,7 +165,7 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
             termios.c_iflag &= !libc::IGNPAR;
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
-                termios.c_iflag &= !libc::CMSPAR;
+                termios.c_cflag &= !libc::CMSPAR;
             }
         }
         Parity::Even => {
@@ -175,7 +175,7 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
             termios.c_iflag &= !libc::IGNPAR;
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
-                termios.c_iflag &= !libc::CMSPAR;
+                termios.c_cflag &= !libc::CMSPAR;
             }
         }
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -184,7 +184,7 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
-            termios.c_iflag |= libc::CMSPAR;
+            termios.c_cflag |= libc::CMSPAR;
         }
         #[cfg(any(target_os = "linux", target_os = "android"))]
         Parity::Space => {
@@ -192,7 +192,7 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
-            termios.c_iflag |= libc::CMSPAR;
+            termios.c_cflag |= libc::CMSPAR;
         }
         #[cfg(not(any(target_os = "linux", target_os = "android")))]
         Parity::Mark => {

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -171,7 +171,7 @@ impl TTYPort {
 
         // Configure the low-level port settings
         let mut termios = termios::get_termios(fd.0)?;
-        termios::set_parity(&mut termios, builder.parity);
+        termios::set_parity(&mut termios, builder.parity)?;
         termios::set_flow_control(&mut termios, builder.flow_control);
         termios::set_data_bits(&mut termios, builder.data_bits);
         termios::set_stop_bits(&mut termios, builder.stop_bits);
@@ -653,7 +653,7 @@ impl SerialPort for TTYPort {
 
     fn set_parity(&mut self, parity: Parity) -> Result<()> {
         let mut termios = termios::get_termios(self.fd)?;
-        termios::set_parity(&mut termios, parity);
+        termios::set_parity(&mut termios, parity)?;
         #[cfg(any(target_os = "ios", target_os = "macos"))]
         return termios::set_termios(self.fd, &termios, self.baud_rate);
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -314,6 +314,8 @@ impl SerialPort for COMPort {
         match dcb.Parity {
             ODDPARITY => Ok(Parity::Odd),
             EVENPARITY => Ok(Parity::Even),
+            MARKPARITY => Ok(Parity::Mark),
+            SPACEPARITY => Ok(Parity::Space),
             NOPARITY => Ok(Parity::None),
             _ => Err(Error::new(
                 ErrorKind::Unknown,

--- a/src/windows/dcb.rs
+++ b/src/windows/dcb.rs
@@ -81,6 +81,8 @@ pub(crate) fn set_parity(dcb: &mut DCB, parity: Parity) {
         Parity::None => NOPARITY,
         Parity::Odd => ODDPARITY,
         Parity::Even => EVENPARITY,
+        Parity::Mark => MARKPARITY,
+        Parity::Space => SPACEPARITY,
     };
 
     dcb.set_fParity(if parity == Parity::None { FALSE } else { TRUE } as DWORD);


### PR DESCRIPTION
CMSPAR is control bit. Tested on CP2108 HW and Debian 12 SW.